### PR TITLE
Update org.nemo.extensions.nemo-terminal.gschema.xml

### DIFF
--- a/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
+++ b/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
@@ -22,7 +22,7 @@
 	    </key>
 	    
 	    <key name="default-visible" type="b">
-	        <default>false</default>
+	        <default>true</default>
 	        <summary>Default visibility of terminal</summary>
 	        <description>When a new Nemo window is opened, this setting determines whether Nemo terminal is visible by default.</description>
 	    </key>


### PR DESCRIPTION
It makes no sense to have a false default as anyone installing it wants it visible.
