### PR TITLE
Display for_later with relative path in context menu.

### DIFF
--- a/nemo-compare/src/nemo-compare.py
+++ b/nemo-compare/src/nemo-compare.py
@@ -93,6 +93,7 @@ class NemoCompareExtension(GObject.GObject, Nemo.MenuProvider):
 		# for paths with remembered items
 		new_paths = list(paths)
 		
+        for_later_relative = None
 		if self.for_later is not None:
 			if len(paths) >= 1:	
 				for_later_relative = os.path.relpath(self.for_later, os.path.dirname(paths[0]))


### PR DESCRIPTION
This fixes the problem that in most cases the relevant part of the path is truncated.
I have also added a colon for better recognize the path.  
