### PR TITLE
[nemo-image-converter] fix rotate dialog - it didn't show because of the obsolete property

### DIFF
--- a/nemo-image-converter/data/nemo-image-rotate.ui
+++ b/nemo-image-converter/data/nemo-image-rotate.ui
@@ -30,7 +30,6 @@
     <property name="border_width">12</property>
     <property name="title" translatable="yes">Rotate Images</property>
     <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-    <property name="has_separator">False</property>
     <child internal-child="vbox">
       <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>


### PR DESCRIPTION
taken from this commit:
https://git.gnome.org/browse/nautilus-image-converter/commit/?id=23441ed6d74b4eba68333c802890cb396721a6d6