### PR TITLE
updated README

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,6 @@ nemo-bzr: part of bzr-gtk, needs to be isolated from it
 NAUTILUS EXTENSIONS MISSING IN NEMO:
 ---------------------------------
 
-arkose-nautilus                 - Desktop application sandboxing - nautilus 
 nautilus-actions                - nautilus extension to configure programs t
 nautilus-clamscan               - Antivirus scanning for Nautilus           
 nautilus-ideviceinfo            - utility showing information of idevices on


### PR DESCRIPTION
arkose is obsolete and not present in the current Ubuntu repos (last seen in Precise), so removing this entry