### PR TITLE
temp fix for the no auto cd problem in recent linux kernels

### DIFF
--- a/nemo-terminal/src/nemo_terminal.py
+++ b/nemo-terminal/src/nemo_terminal.py
@@ -341,6 +341,10 @@ class NemoTerminal(object):
             except IOError:
                 #We can't know...
                 return False
+        elif wchan == "wait_woken":
+            return False
+        elif wchan == "do_wait":
+            return True
         else:
             return True
 


### PR DESCRIPTION
Apparently wchan handling for bash changed in recent linux kernels (>3.19 as far as I know). Added 2 elif for handling current wchan states : wait_woken and do_wait. I tried to get the schedule and n_tty_read states but could not.
The relevancy of the rest of _shell_is_busy thus needs to be further tested.
Works on my machine, confirmed by skualos in linuxmint#113