### PR TITLE
seahorse: Allow building with gnupg 2.1

### DIFF
--- a/nemo-seahorse/configure.ac
+++ b/nemo-seahorse/configure.ac
@@ -57,7 +57,7 @@ AC_ARG_ENABLE(gpg-check,
 	DO_CHECK=$enableval, DO_CHECK=yes)
 
 if test	"$DO_CHECK" = "yes"; then
-	accepted_versions="1.2 1.4 2.0"
+	accepted_versions="1.2 1.4 2.0 2.1"
 	AC_PATH_PROGS(GNUPG, [gpg gpg2], no)
 	ok="no"
 	if test "$GNUPG" != "no"; then


### PR DESCRIPTION
As GNOME does the same with its nautilus-seahorse:
https://git.gnome.org/browse/seahorse-nautilus/commit/?id=0fad0fcf8adca04f9b0a5a8832a268c835fcd9bd

Fixes linuxmint/nemo-extensions#159