### PR TITLE
Nemo Terminal: Clear 'cd' line after changing directory

### DIFF
--- a/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
+++ b/nemo-terminal/src/org.nemo.extensions.nemo-terminal.gschema.xml
@@ -65,7 +65,7 @@
         </key>
         
         <key name="terminal-change-directory-command" type="s">
-           <default>" cd %s"</default>
+           <default>" cd %s && tput cuu1 && tput el"</default>
            <summary>Change directory command</summary>
            <description>The command used by the terminal to change directory. %s is replaced by the shell-quoted directory name in the shell. This command will have a new line appended.</description>
         </key>


### PR DESCRIPTION
By adding '&& tput cuu1 && tput el' to terminal-change-directory-command changing directories becomes much cleaner. tput is a standard unix system command, so it should be found on most (if not all) distributions.