### PR TITLE
audio: fix missing import

### DIFF
--- a/nemo-preview/src/js/viewers/audio.js
+++ b/nemo-preview/src/js/viewers/audio.js
@@ -25,6 +25,7 @@
  *
  */
 
+const GdkPixbuf = imports.gi.GdkPixbuf;
 const Gio = imports.gi.Gio;
 const Gst = imports.gi.Gst;
 const Gtk = imports.gi.Gtk;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/sushi/patch/src/js?id=1c0977f28177109e738ff81a4ac4dcc99c064c76

From 1c0977f28177109e738ff81a4ac4dcc99c064c76 Mon Sep 17 00:00:00 2001
From: Cosimo Cecchi <cosimoc@gnome.org>
Date: Sat, 14 Nov 2015 11:36:10 -0800
Subject: audio: fix missing import

This was causing album art not to display.