### PR TITLE
nemo-emblems: Fix error

### DIFF
--- a/nemo-emblems/nemo-extension/nemo-emblems.py
+++ b/nemo-emblems/nemo-extension/nemo-emblems.py
@@ -135,5 +135,5 @@ class EmblemPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAn
         subprocess.call(["touch", self.filename])
 
     def get_name_and_desc(self):
-        return [_("Nemo Emblems:::Change a folder or file emblem")]
+        return [("Nemo Emblems:::Change a folder or file emblem")]
 


### PR DESCRIPTION
Issue present on mint-18.1

```
caroline@caroline-ThinkPad-T410 ~ $ /usr/lib/nemo/nemo-extensions-list
Initializing nemo-image-converter extension
NEMO_EXTENSION:::NemoImageConverter:::Nemo Image Converter:::Allows image resizing and rotation from the context menu
NEMO_EXTENSION:::NemoShare:::Nemo Share:::Allows you to quickly share a folder from the context menu
NEMO_EXTENSION:::EmblemPropertyPage+NemoPythonTraceback (most recent call last):
  File "/usr/share/nemo-python/extensions/nemo-emblems.py", line 138, in get_name_and_desc
    return [_("Nemo Emblems:::Change a folder or file emblem")]
NameError: global name '_' is not defined
Segmentation fault
```