### PR TITLE
Don't change the mtime when changing a file's emblems

### DIFF
--- a/nemo-emblems/nemo-extension/nemo-emblems.py
+++ b/nemo-emblems/nemo-extension/nemo-emblems.py
@@ -132,7 +132,9 @@ class EmblemPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAn
         self.gio_file.set_attributes_from_info(self.file_info, 0, None)
 
         # touch the file (to force Nemo to re-render its icon)
-        subprocess.call(["touch", self.filename])
+        returncode = subprocess.call(["touch", "-r", self.filename, self.filename])
+        if returncode != 0:
+            subprocess.call(["touch", self.filename])
 
     def get_name_and_desc(self):
         return [("Nemo Emblems:::Change a folder or file emblem")]


### PR DESCRIPTION
This change adds the "-r" option to touch, which reads the timestamps from the file and then applies them to the file.  It's sufficient to generate an inotify event, and the file's mtime doesn't change.

In the event that an OS's touch doesn't support -r, I've added a fallback to the old touch command.