### PR TITLE
preview: fix some gtk warnings

### DIFF
--- a/nemo-preview/data/style/gtk-style.css
+++ b/nemo-preview/data/style/gtk-style.css
@@ -9,7 +9,7 @@ GtkWindow {
 GtkSourceView {
     color: @np_text_color;
     background-color: shade (@np_fg_color, 1.10);
-    font: 10 monospace;
+    font: 10px monospace;
 }
 
 NemoPreviewFontWidget {
@@ -21,13 +21,13 @@ NemoPreviewFontWidget {
     background-color: shade (@np_bg_color, 1.30);
 }
 
-.scrollbar.button:prelight,
-.scrollbar.slider:prelight {
+.scrollbar.button:hover,
+.scrollbar.slider:hover {
     background-color: shade (@np_bg_color, 1.45);
 }
 
-.scrollbar.button:prelight:active,
-.scrollbar.slider:prelight:active {
+.scrollbar.button:hover:active,
+.scrollbar.slider:hover:active {
     background-color: shade (@np_bg_color, 1.70);
 }
 


### PR DESCRIPTION
Fixes

```
(nemo-preview-start:23301): Gtk-WARNING **: Theme parsing error: gtk-style.css:12:12: Not using units is deprecated. Assuming 'px'.

(nemo-preview-start:23301): Gtk-WARNING **: Theme parsing error: gtk-style.css:24:26: The :prelight pseudo-class is deprecated. Use :hover instead.

(nemo-preview-start:23301): Gtk-WARNING **: Theme parsing error: gtk-style.css:25:26: The :prelight pseudo-class is deprecated. Use :hover instead.

(nemo-preview-start:23301): Gtk-WARNING **: Theme parsing error: gtk-style.css:29:26: The :prelight pseudo-class is deprecated. Use :hover instead.

(nemo-preview-start:23301): Gtk-WARNING **: Theme parsing error: gtk-style.css:30:26: The :prelight pseudo-class is deprecated. Use :hover instead.
```