### PR TITLE
mainWindow: fix uninitialized variable

### DIFF
--- a/nemo-preview/src/js/ui/mainWindow.js
+++ b/nemo-preview/src/js/ui/mainWindow.js
@@ -67,6 +67,7 @@ MainWindow.prototype = {
         args = args || {};
 
         this._background = null;
+        this._isFullScreen = false;
         this._pendingRenderer = null;
         this._renderer = null;
         this._texture = null;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/sushi/commit/?id=c254e6b54c91f7f8ba54440e8ab437e6a62ad32f

```
Cjs-Message: JS WARNING: [/usr/share/nemo-preview/js/ui/mainWindow.js 248]: reference to undefined property this._isFullScreen
Cjs-Message: JS WARNING: [resource:///org/cinnamon/cjs/modules/tweener/tweener.js 545]: reference to undefined property properties[istr].arrayIndex
/usr/bin/nemo-preview: line 15:  2885 Segmentation fault      (core dumped) /usr/libexec/nemo-preview-start
```