### PR TITLE
mainWindow: specify GdkX11 version to 3.0

### DIFF
--- a/nemo-preview/src/js/ui/mainWindow.js
+++ b/nemo-preview/src/js/ui/mainWindow.js
@@ -25,6 +25,8 @@
  *
  */
 
+imports.gi.versions.GdkX11 = '3.0';
+
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const GObject = imports.gi.GObject;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/sushi/commit/?id=9abfea53f833a16a5abca194380814cdd8f96761

```
Cjs-Message: JS WARNING: [/usr/share/nemo-preview/js/ui/mainWindow.js 41]: Requiring GdkX11 but it has 2 versions available; use imports.gi.versions to pick one
```