### PR TITLE
[3.6] Update share-dialog.ui

### DIFF
--- a/nemo-share/interfaces/share-dialog.ui
+++ b/nemo-share/interfaces/share-dialog.ui
@@ -24,7 +24,7 @@
         <child>
           <object class="GtkLabel" id="logo_label">
             <property name="visible">True</property>
-            <property name="label" translatable="yes">&lt;big&gt;&lt;b&gt;Folder Sharing&lt;/b&gt;&lt;/big&gt;</property>
+            <property name="label" translatable="yes">Folder Sharing</property>
             <property name="use_markup">True</property>
             <property name="justify">center</property>
           </object>


### PR DESCRIPTION
Windows header display with tags
Russian language translate not corrected displaed!
msgid "<big><b>Folder Sharing</b>></big>"
msgstr "<big><b>Общий доступ к папке<big><b>"
Windows header display with tags - "<big><b>Общий доступ к папке<big><b>"

I edit line 27 in this file for corect error.