### PR TITLE
Fix schema_name not defined and switch to xed

### DIFF
--- a/nemo-preview/src/js/viewers/text.js
+++ b/nemo-preview/src/js/viewers/text.js
@@ -58,10 +58,10 @@ TextRenderer.prototype = {
         this._textLoader.uri = file.get_uri();
 
         this._geditScheme = 'tango';
-        let schemaName = 'org.gnome.gedit.preferences.editor';
+        let schemaName = 'org.x.editor.preferences.editor';
         let installedSchemas = Gio.Settings.list_schemas();
         if (installedSchemas.indexOf(schemaName) > -1) {
-            let geditSettings = new Gio.Settings({ schema: schema_name });
+            let geditSettings = new Gio.Settings({ schema: schemaName });
             let geditSchemeName = geditSettings.get_string('scheme');
             if (geditSchemeName != '')
                 this._geditScheme = geditSchemeName;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/sushi/patch/src/js/viewers/text.js?id=f04402a414f038c598c4a9c32f4b95c8e24ec67f

Fixes

```
(nemo-preview-start:10031): Cjs-WARNING **: JS ERROR: Error calling prepare() on viewer: ReferenceError: schema_name is not defined
TextRenderer.prototype.prepare@/usr/share/nemo-preview/js/viewers/text.js:64:52
```
