### PR TITLE
specify webkit version to 4.0

### DIFF
--- a/nemo-preview/src/js/viewers/html.js
+++ b/nemo-preview/src/js/viewers/html.js
@@ -25,6 +25,7 @@
  *
  */
 
+imports.gi.versions.WebKit2 = '4.0';
 const GtkClutter = imports.gi.GtkClutter;
 const Gtk = imports.gi.Gtk;
 const GLib = imports.gi.GLib;


### PR DESCRIPTION
Fixes

```
Cjs-Message: JS WARNING: [/usr/share/nemo-preview/js/viewers/html.js 31]: Requiring WebKit2 but it has 2 versions available; use imports.gi.versions to pick one2
```
