### PR TITLE
nemo-media-columns: Add track padding

### DIFF
--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -145,7 +145,7 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                 except: pass
                 try: info.artist = audio["artist"][0]
                 except: pass
-                try: info.tracknumber = audio["tracknumber"][0]
+                try: info.tracknumber = "{:0>2}".format(audio["tracknumber"][0])
                 except: pass
                 try: info.genre = audio["genre"][0]
                 except: pass


### PR DESCRIPTION
I don't know if this is an acceptable fix, but it addresses #176.
It pads out single digit track numbers with a 0 to enable proper sorting inside Nemo.