### PR TITLE
nemo-terminal: add l10n support

### DIFF
--- a/makepot
+++ b/makepot
@@ -56,3 +56,6 @@ rm -f nemo-seahorse/tool/*.xml.h
 intltool-extract --type=gettext/glade nemo-share/interfaces/share-dialog.ui
 xgettext --language=C --keyword=_ --keyword=N_ --output=nemo-extensions.pot --join-existing nemo-share/src/*.c nemo-share/src/*.h nemo-share/interfaces/*.ui.h
 rm -f nemo-share/interfaces/*.ui.h
+
+#nemo-terminal
+xgettext --language=Python --keyword=_ --keyword=N_ --output=nemo-extensions.pot --join-existing nemo-terminal/src/*.py

--- a/nemo-seahorse/configure.ac
+++ b/nemo-seahorse/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([nemo-seahorse], [4.0.0],
+AC_INIT([nemo-seahorse], [4.0.1],
         [https://github.com/linuxmint/nemo-extensions/issues],
         [nemo-seahorse])
 

--- a/nemo-seahorse/debian/changelog
+++ b/nemo-seahorse/debian/changelog
@@ -1,3 +1,9 @@
+nemo-seahorse (4.0.1) tessa; urgency=medium
+
+  * 4.0.1
+
+ -- Clement Lefebvre <root@linuxmint.com>  Wed, 28 Nov 2018 01:19:23 +0000
+
 nemo-seahorse (4.0.0) tessa; urgency=medium
 
   * 4.0.0

--- a/nemo-terminal/src/nemo-terminal-prefs.py
+++ b/nemo-terminal/src/nemo-terminal-prefs.py
@@ -10,8 +10,8 @@ from gi.repository import Gtk, Gio, XApp, Gdk
 
 # i18n
 import gettext
-gettext.bindtextdomain('nemo-terminal', '/usr/share/locale')
-gettext.textdomain('nemo-terminal')
+gettext.bindtextdomain('nemo-extensions')
+gettext.textdomain('nemo-extensions')
 _ = gettext.gettext
 
 
@@ -214,7 +214,7 @@ class NemoTerminalPreferencesWindow(XApp.PreferencesWindow):
 
         button.connect("clicked", on_reset_clicked)
 
-        widget = LabeledItem(_("Sequences must be escaped according to python rules. ") +
+        widget = LabeledItem(_("Sequences must be escaped according to python rules.") + " " +
                              _("'%s' is replaced by the quoted directory name."), button)
         widget.label_widget.set_line_wrap(True)
         widget.label_widget.set_max_width_chars(40)


### PR DESCRIPTION
This extension was missed by the makepot script

There's also a gschema.xml file, which has some strings. I didn't
included them, because I don't see, where they are used.