### PR TITLE
Update nemo-media-columns.py: Avoid a NameError

### DIFF
--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -26,7 +26,7 @@ import os
 from urllib import parse
 import gi
 gi.require_version('GExiv2', '0.10')
-from gi.repository import Nemo, GObject, Gtk, GdkPixbuf, GExiv2
+from gi.repository import Nemo, GObject, Gtk, GdkPixbuf, GExiv2, GLib
 # for id3 support
 from mutagen.easyid3 import EasyID3
 from mutagen.mp3 import MP3


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/nemo-python/extensions/nemo-media-columns.py", line 119, in update_cb
    self.do_update_file_info(file)
  File "/usr/share/nemo-python/extensions/nemo-media-columns.py", line 182, in do_update_file_info
    except GLib.Error as e:
NameError: name 'GLib' is not defined
```