### PR TITLE
Hide emblems which end on -symbolic.symbolic.png

### DIFF
--- a/nemo-emblems/nemo-extension/nemo-emblems.py
+++ b/nemo-emblems/nemo-extension/nemo-emblems.py
@@ -56,7 +56,7 @@ class EmblemPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAn
         self.display_names = {}
         icon_names = self.default_icon_theme.list_icons(None)
         for icon_name in icon_names:
-            if not icon_name in HIDE_EMBLEMS and icon_name.startswith('emblem-') and not icon_name.endswith('-symbolic') and not icon_name.startswith('emblem-dropbox') and not icon_name.startswith('emblem-ubuntu') and not icon_name.startswith('emblem-rabbitvcs'):
+            if not icon_name in HIDE_EMBLEMS and icon_name.startswith('emblem-') and not icon_name.endswith(('-symbolic', '-symbolic.symbolic')) and not icon_name.startswith(('emblem-dropbox', 'emblem-ubuntu', 'emblem-rabbitvcs')):
                 # icon_name is emblem
                 icon_info = self.default_icon_theme.lookup_icon(icon_name, 32, 0)
                 display_name = icon_info.get_display_name()


### PR DESCRIPTION
We do not support symbolic png files, so they look pretty ugly.