### PR TITLE
nemo-terminal: Remove useless binary nemo-terminal-prefs

### DIFF
--- a/nemo-terminal/setup.py
+++ b/nemo-terminal/setup.py
@@ -28,7 +28,6 @@ setup(
 
     data_files = [
         ('/usr/share/nemo-python/extensions', ['src/nemo_terminal.py']),
-        ('/usr/bin',                          ['src/nemo-terminal-prefs']),
         ('/usr/share/nemo-terminal',          ['src/nemo-terminal-prefs.py',
                                                'pixmap/logo_120x120.png']),
         ('/usr/share/glib-2.0/schemas',       ['src/org.nemo.extensions.nemo-terminal.gschema.xml'])

--- a/nemo-terminal/src/nemo-terminal-prefs
+++ b/nemo-terminal/src/nemo-terminal-prefs
@@ -1,6 +1,0 @@
-#!/usr/bin/python3
-
-import subprocess
-import sys
-
-sys.exit(subprocess.call(["/usr/share/nemo-terminal/nemo-terminal-prefs.py"]))


### PR DESCRIPTION
This script just calls nemo-terminal-prefs.py. This makes an extra doc 
file required for packagers and should not be here.