### PR TITLE
ensures video duration works when a float

### DIFF
--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -251,7 +251,7 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                             pass
 
                         try:
-                            duration = int(track['duration'])
+                            duration = int(float(track['duration']))
                         except:
                             pass
 


### PR DESCRIPTION
Some files have duration that is a float, causes ValueError: invalid literal for int()