### PR TITLE
simplify meson option handling

### DIFF
--- a/nemo-seahorse/meson.build
+++ b/nemo-seahorse/meson.build
@@ -36,18 +36,10 @@ dbus_glib = dependency('dbus-glib-1', version: '>=0.78')
 cryptui = dependency('cryptui-0.0')
 gcr = dependency('gcr-3', version: '>=3.4.0')
 
-if get_option('libnotify')
-    libnotify = dependency('libnotify', version: '>=0.7.0')
-else
-    libnotify = dependency('', required: false)
-endif
+libnotify = dependency('libnotify', version: '>=0.7.0', required: get_option('libnotify'))
 config.set('HAVE_LIBNOTIFY', libnotify.found())
 
-if get_option('sharing')
-    avahi = dependency('avahi-glib')
-else
-    avahi = dependency('', required: false)
-endif
+avahi = dependency('avahi-glib', required: get_option('sharing'))
 config.set('WITH_SHARING', avahi.found())
 
 

--- a/nemo-seahorse/meson_options.txt
+++ b/nemo-seahorse/meson_options.txt
@@ -1,3 +1,3 @@
 option('gpg-check', type: 'boolean', value: true)
-option('libnotify', type: 'boolean', value: true)
-option('sharing',   type: 'boolean', value: false)
+option('libnotify', type: 'feature', value: 'enabled')
+option('sharing',   type: 'feature', value: 'disabled')


### PR DESCRIPTION
meson has the concept of "feature" options. Rather than either enabling or disabling an optional dependency+feature via true/false boolean type, a feature option accepts "enabled", "disabled", and "auto". By passing the feature option directly to the dependency() lookup, meson knows when/how to look it up without if/else soup.

The new functionality here is:
- auto type will try to detect if the dependency is available and use it
- disabled type will log "Dependency avahi-glib skipped: feature sharing disabled"

For equivalence with the previous option values, the default options continue to force enable or force disable the features. No use of "auto" (but people building the project can configure it that way, if they wish).