### PR TITLE
[media-columns] display bitrate for videos

### DIFF
--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -269,12 +269,18 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                             duration = int(float(track['duration']))
                         except:
                             pass
+                        if not info.bitrate:
+                            try:
+                                info.bitrate = track['other_bit_rate'][0]
+                            except:
+                                pass
 
                     if track["track_type"] == "Audio":
-                        try:
-                            info.bitrate = track['other_bit_rate'][0]
-                        except:
-                            pass
+                        if not info.bitrate:
+                            try:
+                                info.bitrate = track['other_bit_rate'][0]
+                            except:
+                                pass
                         try:
                             info.samplerate = track['other_sampling_rate'][0]
                         except:
@@ -286,6 +292,10 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                             pass
 
                     if track["track_type"] == "General":
+                        try:
+                            info.bitrate = track['other_overall_bit_rate'][0]
+                        except:
+                            pass
                         try:
                             if duration == 0:
                                 duration = int(track['duration'])

--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 # change log:
+# HarHarLinks: fix video bitrate support
 # geb666: original bsc.py, based on work by Giacomo Bordiga
 # jmdsdf: version 2 adds extra ID3 and EXIF tag support
 # jmdsdf: added better error handling for ID3 tags, added mp3 length support, distinguished

--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -269,18 +269,8 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                             duration = int(float(track['duration']))
                         except:
                             pass
-                        if not info.bitrate:
-                            try:
-                                info.bitrate = track['other_bit_rate'][0]
-                            except:
-                                pass
 
                     if track["track_type"] == "Audio":
-                        if not info.bitrate:
-                            try:
-                                info.bitrate = track['other_bit_rate'][0]
-                            except:
-                                pass
                         try:
                             info.samplerate = track['other_sampling_rate'][0]
                         except:


### PR DESCRIPTION
Until now, the pymediainfo library was used on video and non-mp3 mimetypes, but the bitrate field only read for audio tracks.
This resulted in the column only displaying the bitrate of only one (the last) audiotrack, ignoring video and other audio tracks, as well as potentially other tracks.

This patch exchanges displaying the individual track bitrate field `'other_bit_rate'` cumulative bitrate `'other_overall_bit_rate'` if present, i.e. sum of all streams's bitrates as returned by mediainfo.

Support can potentially be further expanded by adding more supported mime types to the list, as the required field seems to always get populated as long as rate calculation (size and runtime) is possible.