### PR TITLE
preview: Fix gtk import

### DIFF
--- a/nemo-preview/src/js/ui/fallbackRenderer.js
+++ b/nemo-preview/src/js/ui/fallbackRenderer.js
@@ -25,6 +25,8 @@
  *
  */
 
+imports.gi.versions.Gtk = '3.0';
+
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 const GtkClutter = imports.gi.GtkClutter;


### PR DESCRIPTION
```
$ nemo-preview 
Cjs-Message: 15:32:04.773: JS WARNING: [/usr/share/nemo-preview/js/ui/fallbackRenderer.js 29]: Requiring Gtk but it has 3 versions available; use imports.gi.versions to pick one
```