### PR TITLE
preview: set gtk 3.0 in ui/main.js for viewers/audio.js

### DIFF
--- a/nemo-preview/src/js/ui/main.js
+++ b/nemo-preview/src/js/ui/main.js
@@ -25,6 +25,8 @@
  *
  */
 
+imports.gi.versions.Gtk = '3.0';
+
 const Format = imports.format;
 const Gettext = imports.gettext;
 


### PR DESCRIPTION
Similar to change in PR https://github.com/linuxmint/nemo-extensions/pull/415, resolves:
```
Cjs-Message: 00:11:40.228: JS WARNING: [/usr/share/nemo-preview/js/viewers/audio.js 31]: Requiring Gtk but it has 3 versions available; use imports.gi.versions to pick one
...
(nemo-preview-start:403013): Cjs-CRITICAL **: 00:11:40.238: JS ERROR: Error: Unsupported type (null), deriving from fundamental (null)
_init@resource:///org/gnome/gjs/modules/core/overrides/Gtk.js:38:5
@/usr/share/nemo-preview/js/viewers/audio.js:31:13

/usr/bin/nemo-preview: line 15: 403013 Segmentation fault      (core dumped) /usr/lib/nemo-preview/nemo-preview-start
```