### PR TITLE
Specify Gst version

### DIFF
--- a/nemo-preview/src/js/viewers/audio.js
+++ b/nemo-preview/src/js/viewers/audio.js
@@ -25,6 +25,7 @@
  *
  */
 
+imports.gi.versions.ClutterGst = '3.0';
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const Gio = imports.gi.Gio;
 const Gst = imports.gi.Gst;


### PR DESCRIPTION
this fixes the error I was getting:

```
Cjs-Message: 14:59:39.333: JS WARNING: [/usr/share/nemo-preview/js/viewers/audio.js 30]: Requiring Gst but it has 2 versions available; use imports.gi.versions to pick one
Cjs-Message: 14:59:39.333: JS WARNING: [/usr/share/nemo-preview/js/viewers/audio.js 31]: Requiring Gtk but it has 3 versions available; use imports.gi.versions to pick one

(nemo-preview-start:23759): GLib-GObject-WARNING **: 14:59:39.341: cannot register existing type 'GtkWidget'

(nemo-preview-start:23759): GLib-GObject-WARNING **: 14:59:39.341: cannot add class private field to invalid type '<invalid>'

(nemo-preview-start:23759): GLib-GObject-WARNING **: 14:59:39.341: cannot add private field to invalid (non-instantiatable) type '<invalid>'

(nemo-preview-start:23759): GLib-GObject-WARNING **: 14:59:39.341: cannot register existing type 'GtkAccessible'

(nemo-preview-start:23759): GLib-GObject-CRITICAL **: 14:59:39.341: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(nemo-preview-start:23759): GLib-CRITICAL **: 14:59:39.341: g_once_init_leave: assertion 'result != 0' failed

(nemo-preview-start:23759): GLib-GObject-CRITICAL **: 14:59:39.341: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(nemo-preview-start:23759): GLib-GObject-WARNING **: 14:59:39.341: cannot register existing type 'GtkBuildable'

(nemo-preview-start:23759): GLib-GObject-CRITICAL **: 14:59:39.341: g_type_interface_add_prerequisite: assertion 'G_TYPE_IS_INTERFACE (interface_type)' failed

(nemo-preview-start:23759): GLib-CRITICAL **: 14:59:39.341: g_once_init_leave: assertion 'result != 0' failed

(nemo-preview-start:23759): GLib-GObject-CRITICAL **: 14:59:39.341: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(nemo-preview-start:23759): GLib-GObject-CRITICAL **: 14:59:39.341: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed

(nemo-preview-start:23759): Cjs-CRITICAL **: 14:59:39.341: JS ERROR: Error: Unsupported type (null), deriving from fundamental (null)
_init@resource:///org/gnome/gjs/modules/core/overrides/Gtk.js:38:5
@/usr/share/nemo-preview/js/viewers/audio.js:31:13

/usr/bin/nemo-preview: line 15: 23759 Segmentation fault      (core dumped) /usr/lib/nemo-preview/nemo-preview-start
```
