### PR TITLE
Fixed nemo-compare not working due to PyGIWarning - gi.require_version('Nemo', '3.0')

### DIFF
--- a/nemo-compare/src/nemo-compare.py
+++ b/nemo-compare/src/nemo-compare.py
@@ -25,6 +25,8 @@ import signal
 from gi.repository import GLib
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+import gi
+gi.require_version('Nemo', '3.0')
 from gi.repository import Nemo, GObject, Gio
 
 sys.path.append("/usr/share/nemo-compare")


### PR DESCRIPTION
I am using pretty dated arch release package but it seems nemo-compare.py in master branch has the same issue. The fix in this PR allows nemo-compare plugin to run on Nemo 3.0.