### PR TITLE
[WIP] audio-tag, ffmpeg vs mutagen => more supported formats

### DIFF
--- a/nemo-audio-tab/debian/control
+++ b/nemo-audio-tab/debian/control
@@ -18,5 +18,6 @@ Depends: ${misc:Depends},
          gir1.2-gtk-3.0,
          gir1.2-glib-2.0,
          python-nemo (>= 3.9.0),
-         python3-mutagen
+         ffmpeg
+         python3-ffmpeg
 Description: View audio tag information from the file manager's properties tab

--- a/nemo-audio-tab/debian/control
+++ b/nemo-audio-tab/debian/control
@@ -19,5 +19,4 @@ Depends: ${misc:Depends},
          gir1.2-glib-2.0,
          python-nemo (>= 3.9.0),
          ffmpeg
-         python3-ffmpeg
 Description: View audio tag information from the file manager's properties tab

--- a/nemo-audio-tab/nemo-extension/nemo-audio-tab.glade
+++ b/nemo-audio-tab/nemo-extension/nemo-audio-tab.glade
@@ -17,12 +17,13 @@
             <property name="vexpand">True</property>
             <property name="row_spacing">4</property>
             <property name="column_spacing">16</property>
+
             <child>
-              <object class="GtkLabel" id="label_title">
+              <object class="GtkLabel" id="labelsample_rate">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Title:</property>
+                <property name="label" translatable="yes">Sample Rate:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -33,11 +34,10 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="title_text">
+              <object class="GtkLabel" id="samplerate_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="hexpand">True</property>
                 <property name="selectable">True</property>
               </object>
               <packing>
@@ -45,12 +45,13 @@
                 <property name="top_attach">0</property>
               </packing>
             </child>
+
             <child>
-              <object class="GtkLabel" id="label_artist">
+              <object class="GtkLabel" id="label_text_duration">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Artist:</property>
+                <property name="label" translatable="yes">Duration:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -61,7 +62,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="artist_text">
+              <object class="GtkLabel" id="duration_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
@@ -72,12 +73,13 @@
                 <property name="top_attach">1</property>
               </packing>
             </child>
+
             <child>
-              <object class="GtkLabel" id="label_album">
+              <object class="GtkLabel" id="label_channels">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Album:</property>
+                <property name="label" translatable="yes">Channels:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -88,7 +90,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="album_text">
+              <object class="GtkLabel" id="channels_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
@@ -99,152 +101,7 @@
                 <property name="top_attach">2</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkLabel" id="label_album_artist">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Album Artist:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="album_artist_text">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_genre">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Genre:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="genre_text">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_year">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Year:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="year_text">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_track_num">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Track #:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="track_number_text">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label_length">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Length:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="length_number">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparator" id="separator1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">8</property>
-                <property name="width">2</property>
-              </packing>
-            </child>
+
             <child>
               <object class="GtkLabel" id="label_text_bitrate">
                 <property name="visible">True</property>
@@ -257,11 +114,11 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">9</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="bitrate_number">
+              <object class="GtkLabel" id="bitrate_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
@@ -269,26 +126,27 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">9</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
+
             <child>
-              <object class="GtkLabel" id="label_sample_rate">
+              <object class="GtkLabel" id="label_codec">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Sample Rate:</property>
+                <property name="label" translatable="yes">Codec:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">10</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="sample_rate_text">
+              <object class="GtkLabel" id="codec_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
@@ -296,26 +154,39 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">10</property>
+                <property name="top_attach">4</property>
               </packing>
             </child>
+
             <child>
-              <object class="GtkLabel" id="label_encoded_by">
+              <object class="GtkSeparator" id="separator1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+
+            <child>
+              <object class="GtkLabel" id="label_other">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Encoded by:</property>
+                <property name="label" translatable="yes">Other:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">11</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="encoded_by_text">
+              <object class="GtkLabel" id="other_text">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
@@ -323,36 +194,10 @@
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">11</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkLabel" id="label_copyright">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Copyright:</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">12</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="copyright_text">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="selectable">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">12</property>
-              </packing>
-            </child>
+
           </object>
         </child>
       </object>

--- a/nemo-audio-tab/nemo-extension/nemo-audio-tab.py
+++ b/nemo-audio-tab/nemo-extension/nemo-audio-tab.py
@@ -43,10 +43,14 @@ def get_meta(filename):
     tags = {}
     tags['duration'] = 'unknown'
     if 'duration' in stream:
-        dur = float(stream["duration"])
-        min_ = int(dur // 60)
-        sec = dur - 60*min_
-        tags['duration'] = f'{min_}:{sec:.3f} (min:s.ms)'
+        total_duration = float(stream["duration"])
+        hours_ = int(total_duration // 3600)
+        total_duration -= 3600*hours_
+        min_ = int(total_duration // 60)
+        total_duration -= 60*min_
+        sec_ = int(total_duration)
+        ms_ = int(1000*(total_duration-sec_))
+        tags['duration'] = f'{hours_:02}:{min_:02}:{sec_:02}.{ms_} (h:min:s.ms)'
 
     tags['bitrate'] = 'unknown'
     if 'bit_rate' in stream:

--- a/nemo-audio-tab/nemo-extension/nemo-audio-tab.py
+++ b/nemo-audio-tab/nemo-extension/nemo-audio-tab.py
@@ -4,18 +4,68 @@
 # RavetcoFX: Forked from nemo-media-columns and nemo-emblems
 
 from urllib import parse
-import locale, gettext, os
-import mutagen
+import locale
+import gettext
+import os
 
-from gi.repository import GObject, Gio, Gtk, Nemo
-# for id3 support
-from mutagen.easyid3 import EasyID3
-from mutagen.mp3 import MP3
-from mutagen.flac import FLAC, StreamInfo
+import ffmpeg
+
+from gi.repository import GObject, Gtk, Nemo
+
+
+def get_meta(filename):
+    """returns None if falure"""
+    try:
+        probe = ffmpeg.probe(filename)
+    except ffmpeg.Error:
+        return None
+    else:
+        stream = next((s for s in probe['streams'] if s['codec_type'] == 'audio'), None)
+        if stream is None:
+            return None
+
+    tags = {}
+    tags['duration'] = 'unknown'
+    if 'duration' in stream:
+        tags['duration'] = f'{float(stream["duration"]):.2f} (s)'
+
+    tags['bitrate'] = 'unknown'
+    if 'bit_rate' in stream:
+        tags['bitrate'] = f'{float(stream["bit_rate"])/1000:.2f} (kbit/s)'
+
+    tags['samplerate'] = 'unknown'
+    if 'sample_rate' in stream:
+        tags['samplerate'] = f'{stream["sample_rate"]} (Hz)'
+
+    tags['channels'] = 'unknown'
+    if 'channels' in stream:
+        tags['channels'] = (
+            str(stream['channels'])
+            + (
+                f' ({stream["channel_layout"]})'
+                if 'channel_layout' in stream else ''
+            )
+        )
+
+    tags['codec'] = 'unknown'
+    if 'codec_long_name' in stream:
+        tags['codec'] = stream['codec_long_name']
+    elif 'codec_name' in stream:
+        tags['codec'] = stream['codec_name']
+
+    tags['other'] = {
+        **(stream['tags'] if 'tags' in stream else {}),
+        **(probe['format']['tags'] if 'tags' in probe['format'] else {}),
+    }
+
+    return tags
+
+
 
 class AudioPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAndDescProvider):
 
     def get_property_pages(self, files):
+
         # files: list of NemoVFSFile
         if len(files) != 1:
             return []
@@ -27,10 +77,11 @@ class AudioPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAnd
         if file.is_directory():
             return []
 
-        if not(file.is_mime_type('audio/mpeg') or file.is_mime_type('audio/flac')):
-            return []
-
         filename = parse.unquote(file.get_uri()[7:])
+
+        tags = get_meta(filename)
+        if tags is None:
+            return []
 
         #GUI
         locale.setlocale(locale.LC_ALL, '')
@@ -51,139 +102,17 @@ class AudioPropertyPage(GObject.GObject, Nemo.PropertyPageProvider, Nemo.NameAnd
                 name = Gtk.Buildable.get_name(obj)
                 setattr(self, name, obj)
 
-        # set defaults to blank to prevent nonetype errors
-        file.add_string_attribute('title', '')
-        file.add_string_attribute('album', '')
-        file.add_string_attribute('artist', '')
-        file.add_string_attribute('albumartist', '')
-        file.add_string_attribute('tracknumber', '')
-        file.add_string_attribute('genre', '')
-        file.add_string_attribute('date', '')
-        file.add_string_attribute('bitrate', '')
-        file.add_string_attribute('samplerate', '')
-        file.add_string_attribute('length', '')
-        file.add_string_attribute('encodedby', '')
-        file.add_string_attribute('copyright', '')
-
         no_info = _("No Info")
-        mutaFile = mutagen.File(filename)
 
-        #MP3
-        if file.is_mime_type('audio/mpeg'):
-            # attempt to read ID3 tag
-            try:
-                audio = EasyID3(filename)
-                # sometimes the audio variable will not have one of these items defined, that's why
-                # there is this long try / except attempt
-                try: file.add_string_attribute('title', audio["title"][0])
-                except: file.add_string_attribute('title', no_info)
-                try: file.add_string_attribute('album', audio["album"][0])
-                except: file.add_string_attribute('album', no_info)
-                try: file.add_string_attribute('artist', audio["artist"][0])
-                except: file.add_string_attribute('artist', no_info)
-                try: file.add_string_attribute('albumartist', audio["performer"][0])
-                except: file.add_string_attribute('albumartist', no_info)
-                try: file.add_string_attribute('tracknumber', audio["tracknumber"][0])
-                except: file.add_string_attribute('tracknumber', no_info)
-                try: file.add_string_attribute('genre', audio["genre"][0])
-                except: file.add_string_attribute('genre', no_info)
-                try: file.add_string_attribute('date', audio["date"][0])
-                except: file.add_string_attribute('date', no_info)
-                try: file.add_string_attribute('encodedby', audio["encodedby"][0])
-                except: file.add_string_attribute('encodedby', no_info)
-                try: file.add_string_attribute('copyright', audio["copyright"][0])
-                except: file.add_string_attribute('copyright', no_info)
-            except:
-                # [SabreWolfy] some files have no ID3 tag and will throw this exception:
-                file.add_string_attribute('title', no_info)
-                file.add_string_attribute('album', no_info)
-                file.add_string_attribute('artist', no_info)
-                file.add_string_attribute('albumartist', no_info)
-                file.add_string_attribute('tracknumber', no_info)
-                file.add_string_attribute('genre', no_info)
-                file.add_string_attribute('date', no_info)
-                file.add_string_attribute('encodedby', no_info)
-                file.add_string_attribute('copyright', no_info)
+        for attribute in ('duration', 'bitrate', 'samplerate', 'channels', 'codec'):
+            file.add_string_attribute(attribute, tags[attribute])
+        if tags['other']:
+            file.add_string_attribute('other', '\n'.join(f'{key}: {val}' for key, val in tags['other'].items()))
+        else:
+            file.add_string_attribute('other', no_info)
 
-                # try to read MP3 information (bitrate, length, samplerate)
-            try:
-                with open(filename, 'rb') as mpfile:
-                    mpinfo = MP3(mpfile).info
-                    file.add_string_attribute('bitrate', str(mpinfo.bitrate/1000) + " Kbps")
-
-                    file.add_string_attribute('samplerate', str(mpinfo.sample_rate) + " Hz")
-                    # [SabreWolfy] added consistent formatting of times in format hh:mm:ss
-                    mp3length = "%02i:%02i:%02i" % ((int(mpinfo.length/3600)), (int(mpinfo.length/60%60)), (int(mpinfo.length%60)))
-                    file.add_string_attribute('length', mp3length)
-            except Exception as e:
-                print(e)
-                file.add_string_attribute('bitrate', no_info)
-                file.add_string_attribute('length', no_info)
-                file.add_string_attribute('samplerate', no_info)
-
-        #FLAC
-        if file.is_mime_type('audio/flac'):
-            try:
-                audio = FLAC(filename)
-                # sometimes the audio variable will not have one of these items defined, that's why
-                # there is this long try / except attempt
-                try: file.add_string_attribute('title', audio["title"][0])
-                except: file.add_string_attribute('title', no_info)
-                try: file.add_string_attribute('album', audio["album"][0])
-                except: file.add_string_attribute('album', no_info)
-                try: file.add_string_attribute('artist', audio["artist"][0])
-                except: file.add_string_attribute('artist', no_info)
-                try: file.add_string_attribute('albumartist', audio["albumartist"][0]) # this tag is different then mp3s
-                except: file.add_string_attribute('albumartist', no_info)
-                try: file.add_string_attribute('tracknumber', audio["tracknumber"][0])
-                except: file.add_string_attribute('tracknumber', no_info)
-                try: file.add_string_attribute('genre', audio["genre"][0])
-                except: file.add_string_attribute('genre', no_info)
-                try: file.add_string_attribute('date', audio["date"][0])
-                except: file.add_string_attribute('date', no_info)
-                try: file.add_string_attribute('encodedby', audio["encoded-by"][0]) # this tag is different then mp3s
-                except: file.add_string_attribute('encodedby', no_info)
-                try: file.add_string_attribute('copyright', audio["copyright"][0])
-                except: file.add_string_attribute('copyright', no_info)
-            except:
-                # [SabreWolfy] some files have no ID3 tag and will throw this exception:
-                file.add_string_attribute('title', no_info)
-                file.add_string_attribute('album', no_info)
-                file.add_string_attribute('artist', no_info)
-                file.add_string_attribute('albumartist', no_info)
-                file.add_string_attribute('tracknumber', no_info)
-                file.add_string_attribute('genre', no_info)
-                file.add_string_attribute('date', no_info)
-                file.add_string_attribute('encodedby', no_info)
-                file.add_string_attribute('copyright', no_info)
-
-                # try to read the FLAC information (length, samplerate)
-            try:
-                fcinfo = StreamInfo(filename)
-
-                file.add_string_attribute('samplerate', str(fcinfo.sample_rate) + " Hz")
-
-                # [SabreWolfy] added consistent formatting of times in format hh:mm:ss
-                flaclength = "%02i:%02i:%02i" % ((int(mutaFile.info.length/3600)), (int(mutaFile.info.length/60%60)), (int(mutaFile.info.length%60)))
-                file.add_string_attribute('length', flaclength)
-                file.add_string_attribute('bitrate', no_info) # flac doesn't really have a bitrate
-            except:
-                file.add_string_attribute('bitrate', no_info)
-                file.add_string_attribute('length', no_info)
-                file.add_string_attribute('samplerate', no_info)
-
-        self.builder.get_object("title_text").set_label(file.get_string_attribute('title'))
-        self.builder.get_object("album_text").set_label(file.get_string_attribute('album'))
-        self.builder.get_object("album_artist_text").set_label(file.get_string_attribute('albumartist'))
-        self.builder.get_object("artist_text").set_label(file.get_string_attribute('artist'))
-        self.builder.get_object("genre_text").set_label(file.get_string_attribute('genre'))
-        self.builder.get_object("year_text").set_label(file.get_string_attribute('date'))
-        self.builder.get_object("track_number_text").set_label(file.get_string_attribute('tracknumber'))
-        self.builder.get_object("sample_rate_text").set_label(file.get_string_attribute('samplerate'))
-        self.builder.get_object("length_number").set_label(file.get_string_attribute('length'))
-        self.builder.get_object("bitrate_number").set_label(file.get_string_attribute('bitrate'))
-        self.builder.get_object("encoded_by_text").set_label(file.get_string_attribute('encodedby'))
-        self.builder.get_object("copyright_text").set_label(file.get_string_attribute('copyright'))
+        for attribute in ('duration', 'bitrate', 'samplerate', 'channels', 'codec', 'other'):
+            self.builder.get_object(f'{attribute}_text').set_label(file.get_string_attribute(attribute))
 
         return [
             Nemo.PropertyPage(name="NemoPython::audio",


### PR DESCRIPTION
Hello, I made this small modification which corrects the following points:
- Support for many more formats (including video formats like avi, mkv, mp4 ...)
- Added the number of channels (mono, stereo, ...)
- Dynamic tag display for more flexibility in formats other than mp3