### PR TITLE
Fix "net usershare returned error 255" error

### DIFF
--- a/nemo-share/src/shares.c
+++ b/nemo-share/src/shares.c
@@ -623,7 +623,7 @@ add_share (ShareInfo *info, GError **error)
 		return FALSE;
 
 	argv[0] = "add";
-	argv[1] = "-l";
+	argv[1] = "--long";
 	argv[2] = info->share_name;
 	argv[3] = info->path;
 	argv[4] = info->comment;


### PR DESCRIPTION
This little change fixes "net usershare returned error 255" error on some Arch based distributions, when trying to create/modify a share from nemo
- Tested on Manjaro Cinnamon