### PR TITLE
Bugfix of nemo-image-converter

### DIFF
--- a/nemo-image-converter/data/nemo-image-resize.ui
+++ b/nemo-image-converter/data/nemo-image-resize.ui
@@ -136,6 +136,7 @@
                             <property name="can_focus">False</property>
                             <property name="has_entry">True</property>
                             <property name="entry_text_column">0</property>
+                            <property name="active">6</property>
                             <items>
                               <item translatable="yes">16x16</item>
                               <item translatable="yes">32x32</item>

--- a/nemo-image-converter/debian/changelog
+++ b/nemo-image-converter/debian/changelog
@@ -1,3 +1,9 @@
+nemo-image-converter (5.4.2) vanessa; urgency=medium
+
+  * 5.4.2
+
+ -- Elmar Wein (erwn16) <elmar_wein@web.de>  Mon, 19 Sep 2022 18:09:23 +0200
+
 nemo-image-converter (5.4.1) vanessa; urgency=medium
 
   * 5.4.1

--- a/nemo-image-converter/src/nemo-image-resizer.c
+++ b/nemo-image-converter/src/nemo-image-resizer.c
@@ -372,9 +372,6 @@ nemo_image_resizer_init(NemoImageResizer *resizer)
 	priv->name_entry = GTK_ENTRY (gtk_builder_get_object (ui, "name_entry"));
 	priv->inplace_radiobutton = GTK_RADIO_BUTTON (gtk_builder_get_object (ui, "inplace_radiobutton"));
 
-	/* Set default item in combo box */
-	/* gtk_combo_box_set_active  (priv->size_combobox, 4);  1024x768 */
-
 	/* Connect signal */
 	g_signal_connect (G_OBJECT (priv->resize_dialog), "response",
 			  (GCallback) nemo_image_resizer_response_cb,


### PR DESCRIPTION
nemo-image-resize.ui_comboboxtext_size received a default size format
ineffective code in nemo-image-resizer.c deleted
bugfix tested with LM 21 Cinnamon