### PR TITLE
Bugfix of nemo-image-converter

### DIFF
--- a/nemo-image-converter/data/nemo-image-resize.ui
+++ b/nemo-image-converter/data/nemo-image-resize.ui
@@ -136,6 +136,7 @@
                             <property name="can_focus">False</property>
                             <property name="has_entry">True</property>
                             <property name="entry_text_column">0</property>
+                            <property name="active">6</property>
                             <items>
                               <item translatable="yes">16x16</item>
                               <item translatable="yes">32x32</item>

--- a/nemo-image-converter/debian/changelog
+++ b/nemo-image-converter/debian/changelog
@@ -1,3 +1,9 @@
+nemo-image-converter (5.4.2) vanessa; urgency=medium
+
+  * 5.4.2
+
+ -- Elmar Wein (erwn16) <elmar_wein@web.de>  Mon, 19 Sep 2022 18:09:23 +0200
+
 nemo-image-converter (5.4.1) vanessa; urgency=medium
 
   * 5.4.1


### PR DESCRIPTION
UI of resizer without a default size format but button resize is activated.
Bugfix: common size format is set in the source code of the UI.
Tested with LM 21 Cinnamon.