### PR TITLE
use CENTER_ALWAYS instead of CENTER for better true centering of the nemo-preview window

### DIFF
--- a/nemo-preview/src/js/ui/mainWindow.js
+++ b/nemo-preview/src/js/ui/mainWindow.js
@@ -97,7 +97,7 @@ MainWindow.prototype = {
                                            hasResizeGrip: false,
                                            skipPagerHint: true,
                                            skipTaskbarHint: true,
-                                           windowPosition: Gtk.WindowPosition.CENTER,
+                                           windowPosition: Gtk.WindowPosition.CENTER_ALWAYS,
                                            application: this._application });
 
         let screen = Gdk.Screen.get_default();


### PR DESCRIPTION
The old `CENTER` option was putting my nemo-preview windows slightly south-east of center, almost like it was trying to position the north-west corner of the window in the center of the screen instead of the actual center of the window in the center of the screen. Using `CENTER_ALWAYS` puts the true center of the window in the true center of the screen.