### PR TITLE
Fixed `nemo-python` examples

### DIFF
--- a/nemo-python/examples/background-image.py
+++ b/nemo-python/examples/background-image.py
@@ -6,6 +6,7 @@ BACKGROUND_KEY = 'picture-uri'
 
 class BackgroundImageExtension(GObject.GObject, Nemo.MenuProvider):
     def __init__(self):
+        super(BackgroundImageExtension, self).__init__()
         self.bgsettings = Gio.Settings.new(BACKGROUND_SCHEMA)
 
     def menu_activate_cb(self, menu, file):

--- a/nemo-python/examples/block-size-column.py
+++ b/nemo-python/examples/block-size-column.py
@@ -1,5 +1,5 @@
 import os
-import urllib
+import urllib.parse
 
 from gi.repository import GObject, Nemo
 
@@ -17,6 +17,6 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider):
         if file.get_uri_scheme() != 'file':
             return
 
-        filename = urllib.unquote(file.get_uri()[7:])
+        filename = urllib.parse.unquote(file.get_uri()[7:])
 
         file.add_string_attribute('block_size', str(os.stat(filename).st_blksize))

--- a/nemo-python/examples/md5sum-property-page.py
+++ b/nemo-python/examples/md5sum-property-page.py
@@ -1,5 +1,5 @@
 import hashlib
-import urllib
+import urllib.parse
 
 from gi.repository import Nemo, Gtk, GObject
 
@@ -18,7 +18,7 @@ class MD5SumPropertyPage(GObject.GObject, Nemo.PropertyPageProvider):
         if file.is_directory():
             return
 
-        filename = urllib.unquote(file.get_uri()[7:])
+        filename = urllib.parse.unquote(file.get_uri()[7:])
 
         self.property_label = Gtk.Label('MD5Sum')
         self.property_label.show()
@@ -35,9 +35,8 @@ class MD5SumPropertyPage(GObject.GObject, Nemo.PropertyPageProvider):
 
         md5sum = hashlib.md5()
         with open(filename,'rb') as f:
-            for chunk in iter(lambda: f.read(8192), ''):
+            while chunk := f.read(8192):
                 md5sum.update(chunk)
-        f.close()
 
         self.value_label.set_text(md5sum.hexdigest())
         self.value_label.show()

--- a/nemo-python/examples/open-terminal.py
+++ b/nemo-python/examples/open-terminal.py
@@ -1,21 +1,19 @@
 # This example is contributed by Martin Enlund
 import os
-import urllib
+import urllib.parse
 
-from gi.repository import Nemo, GObject, GConf
-
-TERMINAL_KEY = '/desktop/gnome/applications/terminal/exec'
+import gi
+from gi.repository import Nemo, GObject
 
 class OpenTerminalExtension(Nemo.MenuProvider, GObject.GObject):
     def __init__(self):
-        self.client = GConf.Client.get_default()
+        pass
 
     def _open_terminal(self, file):
-        filename = urllib.unquote(file.get_uri()[7:])
-        terminal = self.client.get_string(TERMINAL_KEY)
+        filename = urllib.parse.unquote(file.get_uri()[7:])
 
         os.chdir(filename)
-        os.system('%s &' % terminal)
+        os.system('gnome-terminal &')
 
     def menu_activate_cb(self, menu, file):
         self._open_terminal(file)

--- a/nemo-python/examples/update-file-info-async.py
+++ b/nemo-python/examples/update-file-info-async.py
@@ -6,10 +6,10 @@ class UpdateFileInfoAsync(GObject.GObject, Nemo.InfoProvider):
         pass
 
     def update_file_info_full(self, provider, handle, closure, file):
-        print "update_file_info_full"
-        gobject.timeout_add_seconds(3, self.update_cb, provider, handle, closure)
+        print("update_file_info_full")
+        GObject.timeout_add_seconds(3, self.update_cb, provider, handle, closure)
         return Nemo.OperationResult.IN_PROGRESS
 
     def update_cb(self, provider, handle, closure):
-        print "update_cb"
+        print("update_cb")
         Nemo.info_provider_update_complete_invoke(closure, provider, handle, Nemo.OperationResult.FAILED)


### PR DESCRIPTION
Most changes are simple fixes for the python2 -> python3 transition.

Notable other changes:

- In `md5sum-property-page.py`, the code appears to have been infinitely reading the file, even though it's been fully read. Using `while` fixes that.
- In `open-terminal.py`, opted to call `gnome-terminal` directly without trying to read from GConf, because that seems to fail when using the "Open Terminal In %s" menu item.

Verified that all of the examples work on ALT Linux Sisyphus with:

```
nemo-5.8.2-alt1.x86_64
nemo-python-5.6.0-alt1.x86_64
```

**Edit:** https://github.com/linuxmint/nemo-extensions/pull/486/commits/cb7ef6b11e55668a6c00b0a2b91dfaf26931239e is to prevent an error like below from appearing in terminal when launching `$ nemo` (same as init is done in `update-file-info-async.py`):

```
RuntimeError: object at 0x7fdd77d3dd40 of type BackgroundImageExtension is not initialized
```