### PR TITLE
fix permision error issue

### DIFF
--- a/nemo-compare/src/utils.py
+++ b/nemo-compare/src/utils.py
@@ -111,7 +111,10 @@ class NemoCompareConfig:
         '''Adds predefined engines which are installed, but missing in engines list.'''
         system_utils = []
         for path in COMPARATOR_PATHS:
-            system_utils += os.listdir(path)
+            try:
+                system_utils += os.listdir(path)
+            except:
+                pass
         for engine in PREDEFINED_ENGINES:
             if engine not in self.engines and engine in system_utils:
                 self.engines.append(engine)
@@ -138,7 +141,10 @@ class NemoCompareConfig:
 
         system_utils = []
         for path in COMPARATOR_PATHS:
-            system_utils += os.listdir(path)
+            try:
+                system_utils += os.listdir(path)
+            except:
+                pass
         for engine in self.engines:
             if engine not in system_utils:
                 self.engines.remove(engine)


### PR DESCRIPTION
I created hardened linux distribution. /usr/bin and /bin permissions are 111. 
Nemo compare extension require list /usr/bin and It is impossible for distribution.

I fix permission error. If listing is impossible just ignored. 


![resim](https://github.com/user-attachments/assets/cdbf72d2-c330-4d9c-98f9-966617c5f7bc)
