### PR TITLE
Feature/nemo terminal settings

### DIFF
--- a/nemo-terminal/src/nemo-terminal.conf
+++ b/nemo-terminal/src/nemo-terminal.conf
@@ -1,0 +1,12 @@
+
+# ~/.config/nemo/nemo-terminal.conf
+
+[DEFAULT]
+font       = Hack, 10
+foreground = 255,255,255
+background = 53,57,70
+
+[HIGHLIGHT]
+background = 127,63,191
+foreground = 204,204,204
+

--- a/nemo-terminal/src/nemo_terminal.py
+++ b/nemo-terminal/src/nemo_terminal.py
@@ -92,6 +92,22 @@ def _rgba_from_str(s):
 default_font = config.get("DEFAULT", "font",       fallback="Hack, 10")
 fg_rgba      = _rgba_from_str(config.get("DEFAULT", "foreground", fallback="1.0,1.0,1.0,1.0"))
 bg_rgba      = _rgba_from_str(config.get("DEFAULT", "background",fallback="0.20,0.22,0.27,1.0"))                                          
+
+highlight_rgba = _rgba_from_str(
+    config.get(
+        "HIGHLIGHT",
+        "background",
+        fallback="0.50,0.25,0.75,1.0"  # 127/255,63/255,191/255,1.0
+    )
+)
+highlight_fg_rgba = _rgba_from_str(
+    config.get(
+        "HIGHLIGHT",
+        "foreground",
+        fallback="0.8,0.8,0.8,1.0"
+    )
+)
+
 # ─────────────────────────────────────────────────────────────────────────────
 
 
@@ -129,8 +145,10 @@ class NemoTerminal(object):
             bg_rgba,      # from config (default dark gray)
             palette
         )
-        self.term.set_color_highlight(Gdk.RGBA(127/255, 63/255, 191/255, 1.0))
-        self.term.set_color_highlight_foreground(Gdk.RGBA(0.8, 0.8, 0.8, 1.0))        
+        
+        self.term.set_color_highlight(highlight_rgba)
+        self.term.set_color_highlight_foreground(highlight_fg_rgba)
+
 		# ─────────────────────────────────────────────────────────────────────────────
         
 

--- a/nemo-terminal/src/nemo_terminal.py
+++ b/nemo-terminal/src/nemo_terminal.py
@@ -59,6 +59,7 @@ import gi
 gi.require_version('Vte', '2.91')
 gi.require_version('Nemo', '3.0')
 from gi.repository import GObject, Nemo, Gtk, Gdk, Vte, GLib, Gio
+from gi.repository import Pango, Gdk
 
 BASE_KEY = "org.nemo.extensions.nemo-terminal"
 settings = Gio.Settings.new(BASE_KEY)
@@ -85,6 +86,25 @@ class NemoTerminal(object):
         #Term
         self.shell_pid = -1
         self.term = Vte.Terminal()
+
+        #=====================================================================
+        #=====================================================================
+        #=====================================================================
+        #self.term.set_font(Pango.FontDescription.from_string("Noto Mono, 9"))
+        self.term.set_font(Pango.FontDescription.from_string("Hack, 10"))
+        palette = [Gdk.RGBA(0.4, 0.8, 0.8, 1.0)] * 16
+        self.term.set_colors(
+          Gdk.RGBA(1.0, 1.0, 1.0, 1.0),    # Foreground (text) color: white
+          #Gdk.RGBA(0.2, 0.2, 0.2, 1.0),    # Background color: dark gray
+          Gdk.RGBA(53/255, 57/255, 70/255, 1.0),    # Background color: dark gray
+        palette
+        )
+        self.term.set_color_highlight(Gdk.RGBA(127/255, 63/255, 191/255, 1.0))
+        self.term.set_color_highlight_foreground(Gdk.RGBA(0.8, 0.8, 0.8, 1.0))
+        #=====================================================================
+        #=====================================================================
+        #=====================================================================
+
 
         settings.bind("audible-bell", self.term, "audible-bell", Gio.SettingsBindFlags.GET)
 


### PR DESCRIPTION
Load the terminal font & colors from a simple INI file located at ~/.config/nemo/nemo-terminal.conf
