### PR TITLE
nemo-seahorse: Fix build with gpgme >= 2.0.0

### DIFF
--- a/nemo-seahorse/tool/seahorse-pgp-operation.c
+++ b/nemo-seahorse/tool/seahorse-pgp-operation.c
@@ -300,7 +300,6 @@ event_cb (void *data, gpgme_event_io_t type, void *type_data)
         break;
 
     case GPGME_EVENT_NEXT_KEY:
-    case GPGME_EVENT_NEXT_TRUSTITEM:
     default:
         /* Ignore unsupported event types */
         break;


### PR DESCRIPTION
nemo-extensions fails to build with gnupg >= 2.0.0. From https://build.opensuse.org/package/live_build_log/openSUSE:Factory/nemo-extensions/standard/x86_64

````
[   46s] ../tool/seahorse-pgp-operation.c:303:10: error: ‘GPGME_EVENT_NEXT_TRUSTITEM’ undeclared (first use in this function); did you mean ‘GPGME_EVENT_NEXT_KEY’?
[   46s]   303 |     case GPGME_EVENT_NEXT_TRUSTITEM:
[   46s]       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
````

From the gpgme 2.0.0 NEWS:

>  * Removed the entire trustlist feature which worked anyway only for a
>    short period in 2003.  [T4834]

openSUSE bug [boo#1246849](https://bugzilla.opensuse.org/show_bug.cgi?id=1246849)
Identical Arch patch: https://gitlab.archlinux.org/archlinux/packaging/packages/nemo-extensions/-/commit/c90afb05f353f498341b20bf86bdb0004f4dd168