### PR TITLE
fix: use keyword argument for Gtk.Label to avoid deprecation warning

### DIFF
--- a/nemo-terminal/src/nemo-terminal-prefs.py
+++ b/nemo-terminal/src/nemo-terminal-prefs.py
@@ -19,7 +19,7 @@ class LabeledItem(Gtk.Box):
     def __init__(self, label, item):
         super(LabeledItem, self).__init__(orientation=Gtk.Orientation.HORIZONTAL)
 
-        self.label_widget = Gtk.Label(label)
+        self.label_widget = Gtk.Label(label=label)
 
         self.pack_start(self.label_widget, False, False, 6)
         self.pack_end(item, False, False, 6)


### PR DESCRIPTION
## Summary
- Converts positional argument to keyword argument for Gtk.Label
- Eliminates PyGTK deprecation warning in nemo-terminal preferences
- Follows PyGObject API guidelines for GObject constructor calls

## Fixes
Closes #560

## Changes
Modified line 22 in `nemo-terminal/src/nemo-terminal-prefs.py` to use `Gtk.Label(label=label)` instead of `Gtk.Label(label)`.

## Test plan
- Run nemo-terminal-prefs.py
- Verify no deprecation warnings are shown
- Confirm preferences dialog displays correctly