### PR TITLE
Add NemoSelectionProvider Python bindings

### DIFF
--- a/nemo-python/src/nemo-python-object.c
+++ b/nemo-python/src/nemo-python-object.c
@@ -36,6 +36,7 @@
 #include <libnemo-extension/nemo-menu-provider.h>
 #include <libnemo-extension/nemo-property-page-provider.h>
 #include <libnemo-extension/nemo-name-and-desc-provider.h>
+#include <libnemo-extension/nemo-selection-provider.h>
 
 #include <string.h>
 
@@ -550,6 +551,42 @@ nemo_python_object_class_init (NemoPythonObjectClass *class,
 	G_OBJECT_CLASS (class)->finalize = nemo_python_object_finalize;
 }
 
+#define METHOD_NAME "selection_changed"
+static void
+nemo_python_object_selection_changed (NemoSelectionProvider *provider,
+                                      GtkWidget             *window,
+                                      GList                 *files)
+{
+    NemoPythonObject *object = (NemoPythonObject *) provider;
+    PyObject *py_files = NULL, *py_ret = NULL;
+    PyGILState_STATE state = pyg_gil_state_ensure ();
+
+    debug_enter ();
+
+    CHECK_OBJECT (object);
+    CHECK_METHOD_NAME (object->instance);
+
+    CONVERT_LIST (py_files, files);
+
+    py_ret = PyObject_CallMethod (object->instance,
+                                  METHOD_PREFIX METHOD_NAME,
+                                  "(NN)",
+                                  pygobject_new ((GObject *) window),
+                                  py_files);
+    HANDLE_RETVAL (py_ret);
+
+beach:
+    Py_XDECREF (py_ret);
+    pyg_gil_state_release (state);
+}
+#undef METHOD_NAME
+
+static void
+nemo_python_object_selection_provider_iface_init (NemoSelectionProviderInterface *iface)
+{
+    iface->selection_changed = nemo_python_object_selection_changed;
+}
+
 GType 
 nemo_python_object_get_type (GTypeModule *module, 
 								 PyObject 	*type)
@@ -591,6 +628,12 @@ nemo_python_object_get_type (GTypeModule *module,
 
     static const GInterfaceInfo nd_provider_iface_info = {
         (GInterfaceInitFunc) nemo_python_object_name_and_desc_provider_iface_init,
+        NULL,
+        NULL
+    };
+
+    static const GInterfaceInfo selection_provider_iface_info = {
+        (GInterfaceInitFunc) nemo_python_object_selection_provider_iface_init,
         NULL,
         NULL
     };
@@ -661,6 +704,13 @@ nemo_python_object_get_type (GTypeModule *module,
         g_type_module_add_interface (module, gtype, 
                                      NEMO_TYPE_NAME_AND_DESC_PROVIDER,
                                      &nd_provider_iface_info);
+    }
+
+    if (PyObject_IsSubclass (type, (PyObject *) &PyNemoSelectionProvider_Type))
+    {
+        g_type_module_add_interface (module, gtype,
+                                     NEMO_TYPE_SELECTION_PROVIDER,
+                                     &selection_provider_iface_info);
     }
 
     return gtype;

--- a/nemo-python/src/nemo-python.c
+++ b/nemo-python/src/nemo-python.c
@@ -41,6 +41,7 @@ PyTypeObject *_PyNemoMenuProvider_Type;
 PyTypeObject *_PyNemoPropertyPage_Type;
 PyTypeObject *_PyNemoPropertyPageProvider_Type;
 PyTypeObject *_PyNemoOperationHandle_Type;
+PyTypeObject *_PyNemoSelectionProvider_Type;
 
 static const GDebugKey nemo_python_debug_keys[] = {
 	{"misc", NEMO_PYTHON_DEBUG_MISC},
@@ -103,7 +104,8 @@ nemo_python_load_file(GTypeModule *type_module,
 			PyObject_IsSubclass(value, (PyObject*)&PyNemoInfoProvider_Type) ||
 			PyObject_IsSubclass(value, (PyObject*)&PyNemoLocationWidgetProvider_Type) ||
 			PyObject_IsSubclass(value, (PyObject*)&PyNemoMenuProvider_Type) ||
-			PyObject_IsSubclass(value, (PyObject*)&PyNemoPropertyPageProvider_Type))
+			PyObject_IsSubclass(value, (PyObject*)&PyNemoPropertyPageProvider_Type) ||
+			PyObject_IsSubclass(value, (PyObject*)&PyNemoSelectionProvider_Type))
 		{
 			gtype = nemo_python_object_get_type(type_module, value);
 			g_array_append_val(all_types, gtype);
@@ -244,6 +246,7 @@ nemo_python_init_python (void)
 	IMPORT(PropertyPageProvider, "PropertyPageProvider");
     IMPORT(NameAndDescProvider, "NameAndDescProvider");
 	IMPORT(OperationHandle, "OperationHandle");
+    IMPORT(SelectionProvider, "SelectionProvider");
 
 #undef IMPORT
 	

--- a/nemo-python/src/nemo-python.h
+++ b/nemo-python/src/nemo-python.h
@@ -73,4 +73,7 @@ extern PyTypeObject *_PyNemoPropertyPageProvider_Type;
 extern PyTypeObject *_PyNemoOperationHandle_Type;
 #define PyNemoOperationHandle_Type (*_PyNemoOperationHandle_Type)
 
+extern PyTypeObject *_PyNemoSelectionProvider_Type;
+#define PyNemoSelectionProvider_Type (*_PyNemoSelectionProvider_Type)
+
 #endif /* NEMO_PYTHON_H */


### PR DESCRIPTION
Bridge the new NemoSelectionProvider interface to Python, allowing extensions to implement selection_changed(window, files) to be notified when the file selection changes in Nemo.

depends on https://github.com/linuxmint/nemo/pull/3749