### PR TITLE
Assist ID3 track number sorting for collections with more than 100 tracks

### DIFF
--- a/nemo-media-columns/nemo-media-columns.py
+++ b/nemo-media-columns/nemo-media-columns.py
@@ -219,7 +219,7 @@ class ColumnExtension(GObject.GObject, Nemo.ColumnProvider, Nemo.InfoProvider, N
                 except: pass
                 try: info.artist = audio["artist"][0]
                 except: pass
-                try: info.tracknumber = "{:0>2}".format(audio["tracknumber"][0])
+                try: info.tracknumber = "{:0>4}".format(audio["tracknumber"][0])
                 except: pass
                 try: info.genre = audio["genre"][0]
                 except: pass


### PR DESCRIPTION
Existing ID3 extraction left padded the `tracknumber` with a single zero so it could be sorted correctly. This adjustment expands support for lots more tracks.

Downside is that track numbers will be prefixed with zeroes. I suspect this PR would be rejected for that reason, which is fair. I'm assuming that there isn't much control in how columns are sorted in Nemo from an extension perspective?